### PR TITLE
カウントバグを修正

### DIFF
--- a/Kuotore/ViewModels/Training/TrainingViewModel.swift
+++ b/Kuotore/ViewModels/Training/TrainingViewModel.swift
@@ -12,7 +12,8 @@ class TrainingViewModel: ObservableObject {
     // MARK: - Property Wrappers
     @ObservedObject private var bluetoothManager = CentralViewManager.shared
     @Published private(set) var trainingCount = 0
-    @Published private (set) var highestCount = 0
+    @Published private(set) var highestCount = 0
+    @Published private(set) var isCount = false
 
     // MARK: - Initialize
     init() {
@@ -26,8 +27,20 @@ extension TrainingViewModel {
     // MARK: - Methods
     func averageCount(_ distance: Int?) async {
         guard let distance else { return }
+        // Bluetooth通信で距離をたまに取得できないときがあり、０で返ってくるため０の場合は即終了
+        guard distance != 0 else { return }
         let average = 40
-        if distance <= average { trainingCount += 1 }
+        let countLine = average + 100
+        // カウントした後に、countLine以上高く上がらないとカウントしないようにする
+        if self.isCount {
+            guard distance > countLine else { return }
+            // カウントしてからカウントラインまで上がったことを示唆する
+            self.isCount = false
+        }
+        if distance <= average {
+            self.trainingCount += 1
+            self.isCount = true
+        }
     }
 
     @MainActor


### PR DESCRIPTION
## Issue
- [x] #17 

## Overview
- [x] 距離取得にたまに失敗したときは、０が返ってくるのでその場合は、カウントしない
- [x] カウントした後は、一定以上高く上がらないとカウントしないようにした。(以前は、averageよりもdistanceが低ければ無限に増えていた)